### PR TITLE
fix Mix warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,12 +6,12 @@ defmodule RFC3339.Mixfile do
   def project do
     [app: :rfc3339,
      version: @version,
-     description: description,
+     description: description(),
      elixir: "~> 1.2",
-     package: package,
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
Gets rid of the following mix warnings:
```
warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /<my_path>/rfc3339/mix.exs:9

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /<my_path>/rfc3339/mix.exs:11

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /<my_path>/rfc3339/mix.exs:14

```